### PR TITLE
[Technical Support] AUI-885 Dates are not normalized in "_getMonthOverlapDaysOffset" function

### DIFF
--- a/src/aui-calendar/js/aui-calendar.js
+++ b/src/aui-calendar/js/aui-calendar.js
@@ -1297,7 +1297,7 @@ var Calendar = A.Component.create(
 			_getMonthOverlapDaysOffset: function() {
 				var instance = this;
 
-				return Math.abs(DateMath.getDayOffset(instance.getFirstDayOfWeek(), instance.findMonthStart()));
+				return Math.abs(DateMath.getDayOffset(DateMath.safeClearTime(instance.getFirstDayOfWeek()), DateMath.safeClearTime(instance.findMonthStart())));
 			},
 
 			/**


### PR DESCRIPTION
Hi Nate,

it's not a problem on master anymore, that is why I send this to 1.5.x.

Thank you,
Zsigmond
