### PR TITLE
[TECHNICAL-SUPPORT] AUI-930 Weekday short names don't show up on date picker for some locales

### DIFF
--- a/src/aui-calendar/js/aui-calendar.js
+++ b/src/aui-calendar/js/aui-calendar.js
@@ -1231,7 +1231,11 @@ var Calendar = A.Component.create(
 
 				var name = instance._getDayNameShort(weekDay);
 
-				return name.slice(0, name.length - 1);
+				if (name.length > 1) {
+					return name.slice(0, name.length - 1);
+				}
+
+				return name;
 			},
 
 			/**


### PR DESCRIPTION
Please backport to 1.5.x also.
