### PR TITLE
AUI-993 - aui-datepicker-delegate doesn't fire focusin or focusout on Firefox

### DIFF
--- a/src/aui-datepicker/js/aui-datepicker-delegate.js
+++ b/src/aui-datepicker/js/aui-datepicker-delegate.js
@@ -11,16 +11,16 @@ var Lang = A.Lang,
     _DOCUMENT = A.one(A.config.doc),
 
     ACTIVE_INPUT = 'activeInput',
+    BLUR = 'blur',
     CLICK = 'click',
     CONTAINER = 'container',
     DATE_SEPARATOR = 'dateSeparator',
     DATEPICKER_SELECTION = 'datepickerSelection',
+    FOCUS = 'focus',
     MASK = 'mask',
     MOUSEDOWN = 'mousedown',
     SELECTION_CHANGE = 'selectionChange',
     TRIGGER = 'trigger',
-    FOCUSIN = 'focus',
-    FOCUSOUT = 'blur',
     VALUE_EXTRACTOR = 'valueExtractor',
     VALUE_FORMATTER = 'valueFormatter';
 
@@ -76,11 +76,11 @@ DatePickerDelegate.prototype = {
 
         instance._eventHandles = [
             container.delegate(
-                [FOCUSIN, MOUSEDOWN],
+                [FOCUS, MOUSEDOWN],
                 A.bind('_onceUserInteraction', instance), trigger),
 
             container.delegate(
-                FOCUSOUT,
+                BLUR,
                 A.bind('_onUserInteractionRelease', instance), trigger),
 
             container.delegate(


### PR DESCRIPTION
Hey @natecavanaugh,

Attached is an update for http://issues.liferay.com/browse/AUI-993.

Please let me know if you have any questions.  Thanks!
