### PR TITLE
AUI-1137 - Update ACE Editor to original Git SHA when 2.0.0-deprecated was tagged

### DIFF
--- a/.alloy.json
+++ b/.alloy.json
@@ -5,7 +5,7 @@
         "ace": {
             "folder": "../ace-builds",
             "repo": "https://github.com/ajaxorg/ace-builds.git",
-            "version": "45d3068aa7190f08396bcfe134e505fe144c1ccb"
+            "version": "8f2423d10a7cc5680dcdb42a2dd57d9b192e3b34"
         },
         "yui3": {
             "folder": "../yui3",


### PR DESCRIPTION
Hey @natecavanaugh,

Attached is an update for http://issues.liferay.com/browse/AUI-1137.

Please let me know if you have any questions.  Thanks!
