### PR TITLE
[TECHNICAL-SUPPORT] AUI-1194 select option with empty option-text or value can not be create...

### DIFF
--- a/src/aui-datatable/js/aui-datatable-edit.js
+++ b/src/aui-datatable/js/aui-datatable-edit.js
@@ -1282,7 +1282,7 @@ var BaseOptionsCellEditor = A.Component.create({
                     var name = inputName.val();
                     var value = values.item(index).val();
 
-                    if (name && value) {
+                    if (name || value) {
                         options[value] = name;
                     }
                 });


### PR DESCRIPTION
...d with aui-datatable-edit
Hi Nate,

Our opinion (customer too) is that this component should work similar as a html select where we can give option tag without text or value to select tag.
I'm wondering your opinion.
