### PR TITLE
[TECHNICAL-SUPPORT] AUI-1195 aui-datatable-edit - option can not be added

### DIFF
--- a/src/aui-datatable/js/aui-datatable-edit.js
+++ b/src/aui-datatable/js/aui-datatable-edit.js
@@ -1246,7 +1246,7 @@ var BaseOptionsCellEditor = A.Component.create({
             var newRow = A.Node.create(
                 instance._createEditOption(
                     name || '',
-                    value || _EMPTY_STR
+                    value || ''
                 )
             );
 


### PR DESCRIPTION
I think this is a simple bug.
