### PR TITLE
AUI-1194 - BaseOptionsCellEditor does not allow empty values

### DIFF
--- a/src/aui-datatable/js/aui-datatable-edit.js
+++ b/src/aui-datatable/js/aui-datatable-edit.js
@@ -894,9 +894,7 @@ var BaseOptionsCellEditor = A.Component.create({
 					var name = inputName.val();
 					var value = values.item(index).val();
 
-					if (name && value) {
-						options[value] = name;
-					}
+					options[value] = name;
 				});
 
 				instance.set(OPTIONS, options);


### PR DESCRIPTION
Hey @natecavanaugh,

Attached is an update for http://issues.liferay.com/browse/AUI-1194.

NOTE: This is a backport of https://github.com/liferay/alloy-ui/compare/50efdaf51bc62ca14e418f85030965f78a332cad...e84da6475e404aa07efad95d2dca2ce43d9c9b4c

Please let me know if you have any questions.  Thanks!
